### PR TITLE
feat: Add link to SciPy 2023 lightning talk Zenodo archive

### DIFF
--- a/_news/announcement_3.md
+++ b/_news/announcement_3.md
@@ -5,5 +5,5 @@ inline: true
 related_posts: false
 ---
 
-Lightning talk at SciPy 2023 :zap:
- 
+[Lightning talk at SciPy 2023](https://doi.org/10.25080/gerudo-f2bc6f59-013) :zap:
+


### PR DESCRIPTION
Add DOI url for @arliss-NF's SciPy 2023 lightning talk [NumFOCUS Academic Consortium and Open Source Pledge](https://doi.org/10.25080/gerudo-f2bc6f59-013) (c.f. https://github.com/scipy-conference/scipy_proceedings/pull/864). The talk is is published in the [SciPy 2023 conference proceedings](https://conference.scipy.org/proceedings/scipy2023/).